### PR TITLE
生年月日のプルダウン修正

### DIFF
--- a/src/main/java/com/example/demo/util/MapUtil.java
+++ b/src/main/java/com/example/demo/util/MapUtil.java
@@ -14,10 +14,9 @@ public class MapUtil {
 	    {
 	    	Calendar calendar = Calendar.getInstance();
 	    	int thisYear = calendar.get(Calendar.YEAR);
-	    	int startYear = thisYear - 100;
 
-	    	for (Integer i = 0; i < 99; i++) {
-	    		Integer year =startYear + i + 1;
+	    	for (Integer i = 0; i < 100; i++) {
+	    		Integer year = thisYear - ( i +1) ;
 				put(i.toString(),year.toString());
 			};
 	    }


### PR DESCRIPTION
生年月日の年選択プルダウンを開いたとき、1900年から始まっていたので、2019年から下へ表示されるよう修正